### PR TITLE
Change 'GUILD_ID' to 'GUILD_NAME' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ RealmDeathSnitch is a Discord bot that monitors a guild's graveyard and notifies
     Add the following content to keys.env:
     ```
     DISCORD_KEY=your_discord_bot_token
-    GUILD_ID=your_guild_id
+    GUILD_NAME=your_guild_name
     CHANNEL_ID=your_channel_id
     ```
 ### Running with Docker ###


### PR DESCRIPTION
In `README.md`, it says to set `GUILD_ID=your_guild_id` in `keys.env`. However, this causes an error when running `snitch_bot.py`, since line 17 looks for `GUILD_NAME` instead:

`guild = os.getenv("GUILD_NAME")`

This PR fixes this issue by changing `README.md` to set `GUILD_NAME=your_guild_name` in `keys.env` instead.